### PR TITLE
🐳 chore : Docker 환경 구축 #7

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,14 +1,21 @@
 # Application Configuration
 APP_NAME=IEP Planning Support Service
 APP_VERSION=1.0.0
+APP_PORT=8000
+APP_ENV=local
 APP_DEBUG=True
 
-# Database Configuration
+# Database Configuration (app)
 DB_HOST=localhost
 DB_PORT=5432
 DB_USER=postgres
 DB_PASSWORD=postgres
 DB_NAME=iep_db
+
+# Database Configuration (postgres container)
+POSTGRES_USER=postgres
+POSTGRES_PASSWORD=postgres
+POSTGRES_DB=iep_db
 
 # Storage Configuration
 STORAGE_PATH=./storage

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -7,8 +7,6 @@ __pycache__/
 
 # Virtual Environment
 .venv/
-env/
-ENV/
 
 # Environment Variables
 .env

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,19 +1,37 @@
-FROM python:3.14.0-slim-trixie
+FROM python:3.11-slim
 
 # 작업 디렉토리 설정
 WORKDIR /app
 
-# requirements.txt 복사
-COPY requirements.txt .
+# Python 환경 변수
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONUNBUFFERED=1
 
-# 의존성 설치
+# 시스템 의존성 설치 (PostgreSQL 클라이언트 라이브러리 및 빌드 도구)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    gcc \
+    g++ \
+    libpq-dev \
+    libc6-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# pip 업그레이드
+RUN pip install --upgrade pip
+
+# 의존성 파일 복사 및 설치 (레이어 캐싱 최적화)
+COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
-# 소스 코드 복사
-COPY . .
+# 애플리케이션 코드 복사
+COPY app ./app
 
-# FastAPI 포트 노출
+# 스토리지 디렉토리 생성
+RUN mkdir -p /storage
+
+# 포트 노출
 EXPOSE 8000
 
-# Uvicorn 서버 실행 (핫 리로드 지원)
-CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]
+# 개발 모드 실행 명령 (--reload)
+# 프로덕션에서는 --reload 제거 권장
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]

--- a/backend/README.md
+++ b/backend/README.md
@@ -5,24 +5,73 @@
 
 ## Tech Stack
 - **Framework:** FastAPI 0.115.5
-- **Database:** PostgreSQL 17
+- **Database:** PostgreSQL 16
 - **ORM:** SQLAlchemy 2.0.36
-- **Python:** 3.14
+- **Python:** 3.11
+- **Container:** Docker + docker-compose
 
 ## Setup
 
-### 1. Install Dependencies
+### Option 1: Docker (권장)
+
+#### 1. 환경 변수 설정
+```bash
+cd backend
+cp .env.example .env
+# .env 파일 편집 (필요 시)
+```
+
+#### 2. 컨테이너 빌드 및 실행
+```bash
+# 프로젝트 루트에서 실행
+docker compose up --build
+```
+
+#### 3. 검증
+```bash
+# 헬스 체크
+curl http://localhost:8000/health
+
+# DB 연결 확인
+docker compose exec db pg_isready -U postgres
+
+# 스토리지 마운트 확인
+docker compose exec app ls /storage
+```
+
+#### 4. 중지
+```bash
+docker compose down
+
+# 볼륨까지 제거 (데이터 삭제)
+docker compose down -v
+```
+
+### Option 2: 로컬 개발
+
+#### 1. Install Dependencies
 ```bash
 pip install -r requirements.txt
 ```
 
-### 2. Configure Environment
+#### 2. Configure Environment
 ```bash
 cp .env.example .env
 # Edit .env with your configuration
 ```
 
-### 3. Run Application
+#### 3. Run PostgreSQL (Docker)
+```bash
+docker run -d \
+  --name iep_db \
+  -e POSTGRES_USER=postgres \
+  -e POSTGRES_PASSWORD=postgres \
+  -e POSTGRES_DB=iep_db \
+  -p 5432:5432 \
+  postgres:16
+```
+
+#### 4. Run Application
 ```bash
 uvicorn app.main:app --reload
 ```
@@ -31,3 +80,18 @@ uvicorn app.main:app --reload
 - Swagger UI: http://localhost:8000/docs
 - Health Check: http://localhost:8000/health
 
+## Docker Commands
+
+```bash
+# 로그 확인
+docker compose logs -f app
+
+# 컨테이너 내부 접속
+docker compose exec app bash
+
+# DB 접속
+docker compose exec db psql -U postgres -d iep_db
+
+# 개별 서비스 재시작
+docker compose restart app
+```

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,21 +1,54 @@
 services:
-  backend:
-    build: ./backend
-    ports:
-      - '8000:8000'
-    volumes:
-      - ./backend:/app
+  db:
+    image: postgres:16
+    container_name: iep_db
     environment:
-      - PYTHONUNBUFFERED=1
-    restart: unless-stopped
-
-  frontend:
-    build: ./frontend
+      POSTGRES_USER: ${POSTGRES_USER:-postgres}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
+      POSTGRES_DB: ${POSTGRES_DB:-iep_db}
     ports:
-      - '5173:5173'
+      - "${DB_PORT:-5432}:5432"
     volumes:
-      - ./frontend:/app
-      - /app/node_modules
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-postgres}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    networks:
+      - iep_network
+
+  app:
+    build:
+      context: ./backend
+      dockerfile: Dockerfile
+    container_name: iep_backend
     depends_on:
-      - backend
-    restart: unless-stopped
+      db:
+        condition: service_healthy
+    environment:
+      # Docker 환경에서 DB_HOST를 'db'로 오버라이드
+      DB_HOST: db
+      DB_PORT: ${DB_PORT:-5432}
+      POSTGRES_USER: ${POSTGRES_USER:-postgres}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
+      POSTGRES_DB: ${POSTGRES_DB:-iep_db}
+      STORAGE_PATH: /storage
+      APP_PORT: ${APP_PORT:-8000}
+      APP_ENV: ${APP_ENV:-docker}
+      APP_DEBUG: ${APP_DEBUG:-true}
+    ports:
+      - "${APP_PORT:-8000}:8000"
+    volumes:
+      - ./backend/app:/app/app
+      - ./backend/storage:/storage
+    networks:
+      - iep_network
+    command: uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload
+
+volumes:
+  postgres_data:
+
+networks:
+  iep_network:
+    driver: bridge


### PR DESCRIPTION
요약
-- 본 PR은 로컬 개발을 위한 Docker 환경(backend 애플리케이션 + Postgres) 설정과 간단한 실행/검증 절차를 추가합니다.

변경사항
- `docker-compose.yml` (App + Postgres)
- `backend/Dockerfile` (애플리케이션 컨테이너 이미지 정의)
- `backend/.env.example` (환경 변수 템플릿)
- README 및 문서 업데이트(`backend/ghub/docker-docs.md` 참조)

## 테스트 방법

### 1️⃣ Docker 데몬 시작 및 이미지 다운로드
```bash
# Docker Desktop 실행 (GUI)

# PostgreSQL 16 이미지 다운로드
docker pull postgres:16
```

### 2️⃣ PostgreSQL 컨테이너 직접 실행 (초기 테스트)
```bash
# PostgreSQL 컨테이너 실행
docker run -d \
  --name iep_db \
  -e POSTGRES_USER=iep_user \
  -e POSTGRES_PASSWORD=iep_password \
  -e POSTGRES_DB=iep_db \
  -p 5432:5432 \
  -v postgres_data:/var/lib/postgresql/data \
  postgres:16

# DB 연결 확인
docker exec iep_db pg_isready -U iep_user

# PostgreSQL 접속 테스트
docker exec -it iep_db psql -U iep_user -d iep_db
# (exit로 나옴)
```

### 3️⃣ Docker Compose 빌드 시도
```bash
docker compose up --build
# Docker Compose로 재시작
docker compose up -d
```

### 4️⃣ 확인
```bash
# 컨테이너 상태 확인
docker compose ps

# 헬스 체크
curl http://localhost:8000/health

# PostgreSQL 연결 확인
docker compose exec db pg_isready -U postgres

# 스토리지 마운트 확인
docker compose exec app ls /storage
---

## 📋 주요 문제 해결 과정

**Python 3.14 빌드 실패**
   - 원인: `psycopg2-binary`, `pydantic-core` 빌드 오류
   - 해결: Python 3.11로 다운그레이드 + 빌드 도구 추가 (`build-essential`, `libpq-dev`)
---

closed #7 