### PR TITLE
🎉 fix : IEP 파일 목록에 파일 본문 포함 #69

### DIFF
--- a/backend/app/api/iep_versions.py
+++ b/backend/app/api/iep_versions.py
@@ -12,6 +12,7 @@ from app.models.iep_version import IEPVersion
 from app.models.student import Student
 from app.schemas.iep_file import IEPFileResponse
 from app.schemas.iep_version import IEPVersionCreate, IEPVersionResponse
+from app.services.file_storage import load_json_file, FileStorageError
 from app.services.document_generator import (
     generate_docx_stream,
     DocumentNotFoundError,
@@ -153,8 +154,29 @@ def list_iep_files(
         .order_by(IEPFile.updated_at.desc())
         .all()
     )
-    
-    return iep_files
+
+    responses: list[IEPFileResponse] = []
+    for iep_file in iep_files:
+        try:
+            content = load_json_file(iep_file.file_path)
+        except FileStorageError as e:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"IEP file content not found: {e}"
+            ) from e
+
+        responses.append(
+            IEPFileResponse(
+                id=iep_file.id,
+                iep_version_id=iep_file.iep_version_id,
+                file_type=iep_file.file_type,
+                file_path=iep_file.file_path,
+                file_content=content,
+                updated_at=iep_file.updated_at,
+            )
+        )
+
+    return responses
 
 
 @router.get("/iep-versions/{iep_version_id}/docx")

--- a/backend/app/schemas/iep_file.py
+++ b/backend/app/schemas/iep_file.py
@@ -23,6 +23,7 @@ class IEPFileResponse(BaseModel):
     iep_version_id: UUID
     file_type: Literal["student_info", "goal", "weekly_content", "weekly_material"]
     file_path: str
+    file_content: Dict[str, Any] | None = None
     updated_at: datetime
     
     model_config = ConfigDict(from_attributes=True)

--- a/backend/scripts/run_complete_iep_pipeline.py
+++ b/backend/scripts/run_complete_iep_pipeline.py
@@ -32,6 +32,8 @@ scripts_dir = Path(__file__).parent
 from docx import Document
 from docx.enum.text import WD_PARAGRAPH_ALIGNMENT
 
+from app.services.file_storage import save_json_file as save_json_file_service
+
 
 # 도메인 매핑
 KOREAN_DOMAIN_MAPPING = {
@@ -232,17 +234,13 @@ def validate_data_format(goals_data: dict, weekly_plan_data: dict, weekly_materi
 
 
 def save_json_file(iep_version_id: str, file_type: str, content: dict) -> str:
-    """JSON 파일 저장"""
-    storage_dir = backend_dir / "storage" / "iep" / iep_version_id
-    storage_dir.mkdir(parents=True, exist_ok=True)
+    """
+    JSON 파일 저장
     
-    timestamp = int(time.time())
-    file_path = storage_dir / f"{file_type}-{timestamp}.json"
-    
-    with open(file_path, 'w', encoding='utf-8') as f:
-        json.dump(content, f, ensure_ascii=False, indent=2)
-    
-    return str(file_path)
+    파일 경로 패턴: {STORAGE_PATH}/iep/{iep_version_id}/{file_type}-{ts}.json
+    """
+    # 서비스 함수 사용 (일관성 유지)
+    return save_json_file_service(iep_version_id, file_type, content)
 
 
 def generate_docx(goals_data: dict, weekly_plan_data: dict, weekly_materials_data: dict, 

--- a/backend/tests/test_iep_integration.py
+++ b/backend/tests/test_iep_integration.py
@@ -133,6 +133,8 @@ def test_iep_files_query(client, sample_iep_version, mock_ai_generators, sample_
         assert "file_type" in item
         assert "file_path" in item
         assert item["file_type"] in ["student_info", "goal", "weekly_content", "weekly_material"]
+        assert "file_content" in item
+        assert isinstance(item["file_content"], dict)
 
 
 @pytest.mark.integration


### PR DESCRIPTION
IEP 파일 조회에 response
[ { "id":"UUID", "file_type":"string",
”file_content”:{},
"file_path":"string", 
"updated_at":"ISO8601" } ]
로 수정.